### PR TITLE
Standardize options interface across all converters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,13 +53,11 @@ npm run serve  # Start local server
 
 ### Options Interface
 
-Target patterns for new/updated code (see Issues #41, #42 for migration):
+All converters follow these patterns:
 
 1. **Pass options in `convert()` method**, not constructor - allows different options per call
 2. **Wrap underlying library options** - don't expose mammoth, remark-html, etc. directly
 3. **Use our own interfaces** (e.g., `DocxStyleOptions`, `ParagraphStyle`) that we control
-
-Currently only `MarkdownToWordConverter` fully follows these patterns.
 
 ```typescript
 // Good - wrapped options

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ const markdown = await converter.convert(arrayBuffer);
 console.log(markdown);
 ```
 
+#### Customizing Markdown Output
+
+You can customize the generated markdown formatting:
+
+```typescript
+const converter = new WordToMarkdownConverter();
+
+const markdown = await converter.convert('document.docx', {
+  bulletListMarker: '*',    // Use '*' instead of '-' for bullet lists
+  codeBlockStyle: 'fenced', // Use fenced (```) or 'indented' code blocks
+});
+```
+
+**WordToMarkdownOptions:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `bulletListMarker` | `'-'` \| `'*'` \| `'+'` | `'-'` | Character for bullet lists |
+| `codeBlockStyle` | `'fenced'` \| `'indented'` | `'fenced'` | Code block style |
+
 ### Convert Markdown to Word
 
 #### Node.js Environment
@@ -165,7 +184,19 @@ import { MarkdownToHtmlConverter } from 'docx-markdown-utils';
 
 const converter = new MarkdownToHtmlConverter();
 const html = converter.convert('# Hello, **world**!');
+
+// With options - allow raw HTML in markdown
+const htmlWithRaw = converter.convert('<div>Custom HTML</div>', {
+  allowDangerousHtml: true,
+  sanitize: false,
+});
 ```
+
+**MdToHtmlConvertOptions:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `sanitize` | boolean | `true` | Sanitize HTML output to prevent XSS |
+| `allowDangerousHtml` | boolean | `false` | Allow raw HTML in markdown to pass through |
 
 **Supported Markdown features (GFM):**
 - Headings, bold, italic, strikethrough
@@ -244,6 +275,13 @@ To test the browser bundle locally, run `npm run serve` and open `browser-test-b
 
 ### v0.6.0 (Latest)
 
+**Breaking Changes:**
+- `MarkdownToHtmlConverter`: Options moved from constructor to `convert()` method
+- `MdToHtmlConvertOptions`: Now uses `sanitize` and `allowDangerousHtml` instead of `html: object`
+- `WordToMarkdownOptions`: Renamed from `ConvertOptions`, now uses `bulletListMarker` and `codeBlockStyle` instead of `mammoth` and `remarkStringify`
+
+**New Features:**
+- **🎯 Consistent API**: All converters now follow the same pattern: `converter.convert(input, options?)`
 - **🎨 Modern Word Styling**: Default output now matches Microsoft Word's styling (Calibri font, proper heading sizes and colors)
 - **✨ Customizable Paragraph Styles**: New `ParagraphStyle` interface for fine-grained control over fonts, sizes, colors, alignment, and spacing
 - **📝 Heading Styles (H1-H4)**: Individual styling options for each heading level with Word-matching defaults

--- a/src/MarkdownToHtmlConverter.ts
+++ b/src/MarkdownToHtmlConverter.ts
@@ -6,12 +6,21 @@ import remarkHtml from 'remark-html';
 /**
  * Options for the Markdown to HTML conversion process.
  */
-interface MdToHtmlConvertOptions {
-  /** Options passed to remark-html for HTML formatting. */
-  html?: object;
-}
+export interface MdToHtmlConvertOptions {
+  /**
+   * Whether to sanitize HTML output to prevent XSS.
+   * When true (default), potentially dangerous HTML is escaped.
+   * @default true
+   */
+  sanitize?: boolean;
 
-export type { MdToHtmlConvertOptions };
+  /**
+   * Whether to allow raw HTML in the markdown input to pass through.
+   * When false (default), raw HTML tags in markdown are escaped.
+   * @default false
+   */
+  allowDangerousHtml?: boolean;
+}
 
 /**
  * Converts Markdown to HTML.
@@ -22,25 +31,31 @@ export type { MdToHtmlConvertOptions };
  * ```typescript
  * const converter = new MarkdownToHtmlConverter();
  * const html = converter.convert('# Hello');
+ *
+ * // With options
+ * const html = converter.convert('<div>Raw HTML</div>', {
+ *   allowDangerousHtml: true,
+ *   sanitize: false
+ * });
  * ```
  */
 export class MarkdownToHtmlConverter {
-  private options: MdToHtmlConvertOptions;
-
-  constructor(options: MdToHtmlConvertOptions = {}) {
-    this.options = options;
-  }
-
   /**
    * Converts Markdown to HTML using unified processor with GFM support.
    * @param md - The Markdown string to convert.
+   * @param options - Optional configuration for the conversion.
    * @returns The converted HTML string.
    */
-  convert(md: string): string {
+  convert(md: string, options: MdToHtmlConvertOptions = {}): string {
+    const { sanitize = true, allowDangerousHtml = false } = options;
+
     const result = unified()
       .use(remarkParse) // Parse Markdown
       .use(remarkGfm) // GitHub Flavored Markdown support
-      .use(remarkHtml, this.options.html || {}) // Convert to HTML with options
+      .use(remarkHtml, {
+        sanitize,
+        allowDangerousHtml,
+      })
       .processSync(md);
 
     return String(result);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { WordToMarkdownConverter } from './WordToMarkdownConverter.js';
 export { MarkdownToWordConverter } from './MarkdownToWordConverter.js';
 export { MarkdownToHtmlConverter } from './MarkdownToHtmlConverter.js';
-export type { ConvertOptions } from './WordToMarkdownConverter.js';
+export type { WordToMarkdownOptions } from './WordToMarkdownConverter.js';
 export type {
   MdToWordConvertOptions,
   DocxStyleOptions,


### PR DESCRIPTION
## Summary

- Implements #41: Standardize options interface - all converters now accept options in `convert()` method
- Implements #42: Wrap underlying library options - clean interfaces that don't expose implementation details

**Breaking Changes (v0.6.0):**
- `MarkdownToHtmlConverter`: Options moved from constructor to `convert()` method
- `MdToHtmlConvertOptions`: Now uses `sanitize` and `allowDangerousHtml` instead of `html: object`
- `WordToMarkdownOptions`: Renamed from `ConvertOptions`, now uses `bulletListMarker` and `codeBlockStyle` instead of `mammoth` and `remarkStringify`

All converters now follow the same pattern: `converter.convert(input, options?)`

## Test plan

- [x] All 44 existing tests pass
- [x] New tests for sanitization behavior added
- [x] Lint passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)